### PR TITLE
hotfix to solve esp-idf 5.4 compatibily

### DIFF
--- a/src/Json.cpp
+++ b/src/Json.cpp
@@ -1525,8 +1525,8 @@ JsonArray::JsonArray(const String &str) : v(std::vector<Element>()) {
 
 JsonArray::JsonArray(const JsonArray &other) : v(other.v) {}
 
-JsonArray::JsonArray(std::vector<int> &arr) : v(std::vector<Element>()) {
-    for (int i : arr) push(i);
+JsonArray::JsonArray(std::vector<int32_t> &arr) : v(std::vector<Element>()) {
+    for (int32_t i : arr) push(i);
 }
 
 JsonArray &JsonArray::push(const Element &value) {

--- a/src/Json.h
+++ b/src/Json.h
@@ -320,7 +320,7 @@ class JsonArray : public Printable {
     JsonArray();
     JsonArray(const String &str);
     JsonArray(const JsonArray &other);
-    JsonArray(std::vector<int> &arr);
+    JsonArray(std::vector<int32_t> &arr);
     explicit JsonArray(const char *str);
 
     JsonArray &push(const Element &value);


### PR DESCRIPTION
ESP-IDF classifies the coversion from 'int' to 'const Element' as ambiguous.
By changing the JsonArray function to 'int32_t' instead of 'int' this resolves the compile time error.